### PR TITLE
Allow non-standard nameserver ports

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -49,10 +49,16 @@ func (r *Resolver) Lookup(net string, req *dns.Msg) (message *dns.Msg, err error
 
 }
 
+// Namservers return the array of nameservers, with port number appended.
+// '#' in the name is treated as port separator, as with dnsmasq.
 func (r *Resolver) Nameservers() (ns []string) {
 	for _, server := range r.config.Servers {
-		nameserver := server + ":" + r.config.Port
-		ns = append(ns, nameserver)
+		if i := strings.IndexByte(server, '#'); i > 0 {
+			server = server[:i] + ":" + server[i+1:]
+		} else {
+			server = server + ":" + r.config.Port
+		}
+		ns = append(ns, server)
 	}
 	return
 }


### PR DESCRIPTION
For example Consul uses port 8600.
With this patch, I can add
  nameserver 127.0.0.1#8600
to my godns-specific resolv.conf.