### PR TITLE
Add negative cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -58,7 +58,7 @@ type MemoryCache struct {
 	Backend  map[string]Mesg
 	Expire   time.Duration
 	Maxcount int
-	mu       *sync.RWMutex
+	mu       sync.RWMutex
 }
 
 func (c *MemoryCache) Get(key string) (*dns.Msg, error) {
@@ -92,9 +92,9 @@ func (c *MemoryCache) Set(key string, msg *dns.Msg) error {
 }
 
 func (c *MemoryCache) Remove(key string) {
-	c.mu.RLock()
+	c.mu.Lock()
 	delete(c.Backend, key)
-	c.mu.RUnlock()
+	c.mu.Unlock()
 }
 
 func (c *MemoryCache) Exists(key string) bool {


### PR DESCRIPTION
Cache negative results, too, but only with half TTL, as configured.

Plus move caching to non-pointer dns.Msg - halve the memory usage,
and get rid of "mesg.Id = req.Id" data race (build with -race flag)
at once without locking.