### PR TITLE
pass the whole response

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -47,9 +47,9 @@ func (r *Resolver) Lookup(net string, req *dns.Msg) (message *dns.Msg, err error
 		}
 		if r != nil && r.Rcode != dns.RcodeSuccess {
 			Debug("%s failed to get an valid answer on %s", qname, nameserver)
-			return
+		} else {
+			Debug("%s resolv on %s (%s) ttl: %d", UnFqdn(qname), nameserver, net, rtt)
 		}
-		Debug("%s resolv on %s (%s) ttl: %d", UnFqdn(qname), nameserver, net, rtt)
 		select {
 		case res <- r:
 		default:


### PR DESCRIPTION
Answers are passed just on success resulting in not passing the right response codes. This change solves the problem, however could introduce further issues later in the processing, which is worth investigating. Basic tests are passing without issues.

Change based on this issue:
https://github.com/kenshinx/godns/issues/20