### PR TITLE
use net.JoinHostPort()

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -93,9 +94,9 @@ func (r *Resolver) Lookup(net string, req *dns.Msg) (message *dns.Msg, err error
 func (r *Resolver) Nameservers() (ns []string) {
 	for _, server := range r.config.Servers {
 		if i := strings.IndexByte(server, '#'); i > 0 {
-			server = server[:i] + ":" + server[i+1:]
+			server = net.JoinHostPort(server[:i], server[i+1:])
 		} else {
-			server = server + ":" + r.config.Port
+			server = net.JoinHostPort(server, r.config.Port)
 		}
 		ns = append(ns, server)
 	}

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net"
 	"strconv"
 	"time"
 
@@ -15,11 +16,10 @@ type Server struct {
 }
 
 func (s *Server) Addr() string {
-	return s.host + ":" + strconv.Itoa(s.port)
+	return net.JoinHostPort(s.host, strconv.Itoa(s.port))
 }
 
 func (s *Server) Run() {
-
 	Handler := NewHandler()
 
 	tcpHandler := dns.NewServeMux()


### PR DESCRIPTION
fixes this bug when upstream DNS-Servers support IPv6

`2017/02/07 05:49:21 [WARN] error:dial udp: too many colons in address fd00::5e49:79ff:fecc:8541:53
`