### PR TITLE
Add audit backend basic implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ Domain-specific nameservers configuration, formatting keep compatible with Dnsma
 More cases please refererence [dnsmasq-china-list](https://github.com/felixonmars/dnsmasq-china-list)
 
 
+#### audit
+
+Only redis storage backend is currently implemented.
+
+Audit logs are in format:
+
+```
+{ "remoteaddr": "127.0.0.1", "domain": "domain.com", "qtype": "A", "timestamp": "2019-04-15T12:16:21.875492605Z" }
+```
+
+Backend uses lists to store logs in redis.
+
+Logs grouped by hour.
+
+Redis keys have format:
+
+```
+audit-YYYY-MM-DDTHH:00
+```
+
+Example request to get audit logs from redis:
+
+```
+LRANGE audit-2019-04-15T00:00 0 -1
+```
+
+
 #### cache
 
 Only the local memory storage backend is currently implemented.  The redis backend is in the todo list

--- a/audit.go
+++ b/audit.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hoisie/redis"
+)
+
+const AUDIT_LOG_OUTPUT_BUFFER = 1024
+
+type AuditLogger interface {
+	Run()
+	Write(mesg *AuditMesg)
+}
+
+type AuditMesg struct {
+	RemoteAddr string    `json:"remoteaddr"`
+	Domain     string    `json:"domain"`
+	QType      string    `json:"qtype"`
+	Timestamp  time.Time `json:"timestamp"`
+}
+
+func NewAuditMessage(remoteAddr string, domain string, qtype string) *AuditMesg {
+	return &AuditMesg{
+		RemoteAddr: remoteAddr,
+		Domain:     domain,
+		QType:      qtype,
+		Timestamp:  time.Now(),
+	}
+}
+
+type RedisAuditLogger struct {
+	backend *redis.Client
+	mesgs   chan *AuditMesg
+	expire  int64
+}
+
+func NewRedisAuditLogger(rs RedisSettings, expire int64) AuditLogger {
+	rc := &redis.Client{Addr: rs.Addr(), Db: rs.DB, Password: rs.Password}
+	auditLogger := &RedisAuditLogger{
+		backend: rc,
+		mesgs:   make(chan *AuditMesg, AUDIT_LOG_OUTPUT_BUFFER),
+		expire:  expire,
+	}
+	go auditLogger.Run()
+	return auditLogger
+}
+
+func (rl *RedisAuditLogger) Run() {
+	for {
+		select {
+		case mesg := <-rl.mesgs:
+			jsonMesg, err := json.Marshal(mesg)
+			if err != nil {
+				logger.Error("Can't write to redis audit log: %v", err)
+				continue
+			}
+			redisKey := fmt.Sprintf("audit-%s:00", mesg.Timestamp.Format("2006-01-02T15"))
+			err = rl.backend.Rpush(redisKey, jsonMesg)
+			if err != nil {
+				logger.Error("Can't write to redis audit log: %v", err)
+				continue
+			}
+			_, err = rl.backend.Expire(redisKey, rl.expire)
+			if err != nil {
+				logger.Error("Can't set expiration for redis audit log: %v", err)
+				continue
+			}
+		}
+	}
+}
+
+func (rl *RedisAuditLogger) Write(mesg *AuditMesg) {
+	rl.mesgs <- mesg
+}

--- a/etc/godns.conf
+++ b/etc/godns.conf
@@ -39,6 +39,11 @@ file = "./godns.log"
 level = "INFO"  #DEBUG | INFO |NOTICE | WARN | ERROR  
 
 
+# [audit]
+# backend option [redis|file]
+# file backend not implemented yet
+# backend = "redis"
+# expire = 864000 # 10 days
 
 [cache]
 # backend option [memory|memcache|redis]	

--- a/settings.go
+++ b/settings.go
@@ -31,6 +31,7 @@ type Settings struct {
 	Log          LogSettings       `toml:"log"`
 	Cache        CacheSettings     `toml:"cache"`
 	Hosts        HostsSettings     `toml:"hosts"`
+	Audit        AuditSettings     `toml:"audit"`
 }
 
 type ResolvSettings struct {
@@ -65,6 +66,11 @@ type LogSettings struct {
 	Stdout bool
 	File   string
 	Level  string
+}
+
+type AuditSettings struct {
+	Expire  int64
+	Backend string
 }
 
 func (ls LogSettings) LogLevel() int {


### PR DESCRIPTION
- Add audit backend basic implementation;
- Add redis audit backend;
- Update README.

For audit purposes sometimes you want to have machine readable audit log.

Implement some basic functions for IDS/IPS system connection.

By default audit log disabled.