### PR TITLE
Consider sub-domains in hosts wildcards

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hoisie/redis"
-	"golang.org/x/net/publicsuffix"
 )
 
 type Hosts struct {
@@ -110,18 +109,9 @@ func (r *RedisHosts) Get(domain string) ([]string, bool) {
 		return strings.Split(ip, ","), true
 	}
 
-	sld, err := publicsuffix.EffectiveTLDPlusOne(domain)
-	if err != nil {
-		return nil, false
-	}
-
 	for host, ip := range r.hosts {
 		if strings.HasPrefix(host, "*.") {
-			old, err := publicsuffix.EffectiveTLDPlusOne(host)
-			if err != nil {
-				continue
-			}
-			if sld == old {
+			if strings.HasSuffix(domain, strings.TrimPrefix(host, "*")) {
 				return strings.Split(ip, ","), true
 			}
 		}
@@ -166,18 +156,9 @@ func (f *FileHosts) Get(domain string) ([]string, bool) {
 		return []string{ip}, true
 	}
 
-	sld, err := publicsuffix.EffectiveTLDPlusOne(domain)
-	if err != nil {
-		return nil, false
-	}
-
 	for host, ip := range f.hosts {
 		if strings.HasPrefix(host, "*.") {
-			old, err := publicsuffix.EffectiveTLDPlusOne(host)
-			if err != nil {
-				continue
-			}
-			if sld == old {
+			if strings.HasSuffix(domain, strings.TrimPrefix(host, "*")) {
 				return []string{ip}, true
 			}
 		}

--- a/log.go
+++ b/log.go
@@ -151,7 +151,7 @@ func (h *FileHandler) Setup(config map[string]interface{}) error {
 
 	if file, ok := config["file"]; ok {
 		h.file = file.(string)
-		output, err := os.Create(h.file)
+		output, err := os.OpenFile(h.file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When I inserted *.subdomain.example.com in the hosts file, every sub-domains under example.com have been converted to IP in hosts.

I patched this problem